### PR TITLE
Bug 552 detaching member grom group not working in directory emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor
 composer.lock
 .phpunit.result.cache
+.composer
+.phpunit.cache/

--- a/src/Testing/Emulated/EmulatesModelQueries.php
+++ b/src/Testing/Emulated/EmulatesModelQueries.php
@@ -89,7 +89,7 @@ trait EmulatesModelQueries
         foreach ($attributes as $attribute => $value) {
             if (empty($value)) {
                 $model->{$attribute} = null;
-            } elseif (Arr::exists($model->{$attribute} ?? [], $attribute)) {
+            } elseif (Arr::exists($model->attributesToArray() ?? [], $attribute)) {
                 $model->{$attribute} = array_values(
                     array_diff($model->{$attribute}, (array) $value)
                 );

--- a/tests/Feature/Emulator/EmulatedModelQueryTest.php
+++ b/tests/Feature/Emulator/EmulatedModelQueryTest.php
@@ -598,19 +598,11 @@ class EmulatedModelQueryTest extends TestCase
 
         $this->assertTrue($user->groups()->exists($group));
         $this->assertTrue($group->members()->exists($user));
-    }
-
-    public function test_remove_has_many_relationship()
-    {
-        $group = Group::create(['cn' => 'Accounting']);
-        $user = User::create(['cn' => 'John']);
-
-        $user->groups()->attach($group);
-        // Make sure group is attached for next part of test
-        $this->assertTrue($user->groups()->exists($group));
 
         $user->groups()->detach($group);
+
         $this->assertFalse($user->groups()->exists($group));
+        $this->assertFalse($group->members()->exists($user));
     }
 
     public function test_has_one_relationship()

--- a/tests/Feature/Emulator/EmulatedModelQueryTest.php
+++ b/tests/Feature/Emulator/EmulatedModelQueryTest.php
@@ -600,6 +600,19 @@ class EmulatedModelQueryTest extends TestCase
         $this->assertTrue($group->members()->exists($user));
     }
 
+    public function test_remove_has_many_relationship()
+    {
+        $group = Group::create(['cn' => 'Accounting']);
+        $user = User::create(['cn' => 'John']);
+
+        $user->groups()->attach($group);
+        // Make sure group is attached for next part of test
+        $this->assertTrue($user->groups()->exists($group));
+
+        $user->groups()->detach($group);
+        $this->assertFalse($user->groups()->exists($group));
+    }
+
     public function test_has_one_relationship()
     {
         $manager = User::create(['cn' => 'John']);


### PR DESCRIPTION
original issue: https://github.com/DirectoryTree/LdapRecord-Laravel/issues/552